### PR TITLE
(google sheets api) create new google sheets in user's drive after google oauth

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    packagingOptions {
+        resources.excludes.add("META-INF/*")
+    }
 }
 
 apply plugin: 'com.android.application'
@@ -59,6 +62,10 @@ dependencies {
     // Material Design 3
     implementation 'com.google.android.material:material:1.5.0'
 
-    // Google OAuth2
+    // Google OAuth2 and Sheets
     implementation 'com.google.android.gms:play-services-auth:20.2.0'
+    implementation 'com.google.api-client:google-api-client:1.33.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-sheets:v4-rev20210629-1.32.1'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:0.1.0'
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
 
     <!-- google oauth -->
     <string name="google_client_id">688581340511-niasmvfpdeh1kpt8ccgufc4a8sf5ob4i.apps.googleusercontent.com</string>
+    <string name="google_client_secret">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</string>
 
     <!-- Categories array for spinner (adding transactions) options -->
     <array name="categoriesAdd">


### PR DESCRIPTION
After user completes the Google OAuth, the app asks for spreadsheet creation and editing permission. Once granted, the app programmatically and asynchronously creates an empty spreadsheet in the user's Google Drive.
The next step would be to fetch all the transaction data from Parse and populate the sheet.

<img width="703" alt="image" src="https://user-images.githubusercontent.com/49424605/181080471-a815d6eb-d905-4ffb-a6c4-2f93add12069.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/49424605/181080558-54c3fc44-0971-40e8-8b06-dbe59c74e6c6.png">
