### PR TITLE
(ui polish) display a popup after adding transaction and adjust theme colors accordingly

### DIFF
--- a/app/src/main/java/com/example/coinage/fragments/AddTransactionFragment.java
+++ b/app/src/main/java/com/example/coinage/fragments/AddTransactionFragment.java
@@ -36,6 +36,7 @@ import com.chaquo.python.android.AndroidPlatform;
 import com.example.coinage.MainActivity;
 import com.example.coinage.R;
 import com.example.coinage.models.Transaction;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 import com.parse.ParseException;
@@ -158,6 +159,16 @@ public class AddTransactionFragment extends Fragment {
                 saveTransaction(currentUser, date, amount, category, description);
                 // return to Home view after transaction is saved
                 MainActivity.bottomNavigationView.setSelectedItemId(R.id.action_home);
+                // show dialog
+                new MaterialAlertDialogBuilder(context, R.style.AlertDialogTheme)
+                        .setTitle("How did you feel about that purchase?")
+                        .setNeutralButton("Regretting it...", (dialog, which) -> {
+                            Log.i(TAG, "User is unhappy with purchase");
+                        })
+                        .setPositiveButton("Good buy!", (dialog, which) -> {
+                            Log.i(TAG, "User is happy with purchase");
+                        })
+                        .show();
             } catch (java.text.ParseException e) {
                 e.printStackTrace();
             }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,5 +9,6 @@
     <color name="dark_gray">#393939</color>
     <color name="white">#FFFFFFFF</color>
     <color name="yellow">#FFDD66</color>
-    <color name="dark_yellow">#E9B531</color>
+    <color name="darker_yellow">#FAC330</color>
+    <color name="dark_yellow">#FBB805</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,7 +3,7 @@
     <style name="Theme.Coinage" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/yellow</item>
-        <item name="colorPrimaryVariant">@color/yellow</item>
+        <item name="colorPrimaryVariant">@color/darker_yellow</item>
         <item name="colorOnPrimary">@color/black</item>
         <!-- Secondary brand color. -->
         <item name="colorSecondary">#f5a133</item>
@@ -42,5 +42,19 @@
     <style name="ThemeOverlay.App.Card" parent="">
         <item name="colorSurface">@color/yellow</item>
         <item name="colorOnSurface">@color/black</item>
+    </style>
+
+    <!-- dialog popups -->
+    <style name="AlertDialogTheme" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">
+        <item name="buttonBarNeutralButtonStyle">@style/NeutralButtonStyle</item>
+        <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
+    </style>
+
+    <style name="NeutralButtonStyle" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
+        <item name="android:textColor">@color/dark_yellow</item>
+    </style>
+
+    <style name="PositiveButtonStyle" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
+        <item name="android:textColor">@color/dark_yellow</item>
     </style>
 </resources>


### PR DESCRIPTION
Added a feature where users see a popup (material design dialog) that encourages them to reflect on their purchase. Added a new yellow color for the text of the dialog options.

<img width="397" alt="image" src="https://user-images.githubusercontent.com/49424605/182445886-1eb9b233-449e-4b3e-b825-f208f59a085a.png">
